### PR TITLE
Fix: Support Claude by converting dots to underscores in method names

### DIFF
--- a/McpServer.php
+++ b/McpServer.php
@@ -82,7 +82,9 @@ class McpServer extends JsonRpcServer
      */
     protected function mcpToolsCall($args)
     {
-        $method = $args['name'];
+        // Some LLMs (e.g. Claude) don't allow underscores in method names, so we replace them with dots.
+        // We have to convert them back to underscores for the actual call.
+        $method = str_replace('_', '.', $args['name']);
         $params = $args['arguments'];
         $result = parent::call($method, $params);
 

--- a/SchemaGenerator.php
+++ b/SchemaGenerator.php
@@ -33,7 +33,7 @@ class SchemaGenerator extends OpenAPIGenerator
             $args = $call->getArgs();
 
             $tools[] = [
-                'name' => $method,
+                'name' => str_replace('.', '_', $method),
                 'description' => $call->getDescription(),
                 'inputSchema' => $args ? $this->getMethodArguments($args)['schema'] : $nullSchema
             ];


### PR DESCRIPTION
## Summary
- Adds support for Claude LLM by handling method name conversion
- Claude doesn't allow dots in method names, so we convert them to underscores
- The conversion happens both ways: dots to underscores when exposing methods, and underscores back to dots when calling them

## Changes
- Modified `SchemaGenerator.php` to replace dots with underscores when generating method names
- Modified `McpServer.php` to convert underscores back to dots when processing method calls
- Added explanatory comments about the conversion

This ensures compatibility with Claude while maintaining the original DokuWiki API method naming conventions.